### PR TITLE
[WIP] Implement Redis caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "d3-time-format": "^2.1.3",
     "express": "^4.17.1",
     "popper.js": "^1.15.0",
+    "redis": "^2.8.0",
     "sqlite3": "^4.0.9",
     "tooltip.js": "^1.3.2"
   }

--- a/server.js
+++ b/server.js
@@ -19,7 +19,14 @@ redisClient.on("error", function (err) {
     console.log("Redis Error: " + err);
 });
 
-async function checkForCachedVersion(key) {
+function normalizeKey(key) {
+    // Assumes a querystring as key with parameters separated by "&".
+    return key.split("&").sort().join("&");
+}
+
+async function checkForCachedVersion(qs) {
+    const key = normalizeKey(qs);
+    console.log(key);
     let value;
     if (redisClient.connected) {
         let result = await getAsync(`data:${key}`);
@@ -31,7 +38,8 @@ async function checkForCachedVersion(key) {
     return value;
 }
 
-function cacheResultSet(key, data) {
+function cacheResultSet(qs, data) {
+    const key = normalizeKey(qs);
     if (redisClient.connected) {
         let ttl = 60 * 60 * 24;
         redisClient.set(`data:${key}`, JSON.stringify(data), 'EX', ttl);


### PR DESCRIPTION
- [x] Implement simple caching of BQ queries
- [x] Count cache hits, to be used later to explore most hit views
- [x] Ensure keys are stable (sort params alphabetically)
- [x] Gracefully fallback to BQ queries if no Redis server
- [x] Use environment variables for Redis connection
- [ ] Add background updates. This involves extending the Redis TTL to 7 days, adding a `lastRun` key, and if `lastRun` > 1 day, re-running the BQ query and storing the result, while also returning the stale data to be displayed in the interim.
- [ ] With background updates, add a polling API endpoint to return the new data once it is ready.
