### PR TITLE
WIP: Add "Any Fenix Baseline Activity" usage criterion

### DIFF
--- a/server.js
+++ b/server.js
@@ -135,6 +135,11 @@ WITH day_0_base AS (
   SELECT
     *
   FROM
+    \`moz-fx-data-shared-prod.analysis.klukas_smoot_usage_fenix\`
+  UNION ALL
+  SELECT
+    *
+  FROM
     \`moz-fx-data-shared-prod.telemetry_derived.smoot_usage_fxa_compressed_v2\`
 ),
 --
@@ -187,6 +192,11 @@ day_13_base AS (
     *
   FROM
     \`moz-fx-data-shared-prod.telemetry_derived.smoot_usage_nondesktop_compressed_v2\`
+  UNION ALL
+  SELECT
+    *
+  FROM
+    \`moz-fx-data-shared-prod.analysis.klukas_smoot_usage_fenix\`
   UNION ALL
   SELECT
     *

--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -89,7 +89,20 @@
         "label": "Any Fenix Activity",
         "key": "Any Fenix Activity",
         "disabledDimensions": ["os", "channel", "attributed"],
-        "shortDescription": "The profile has sent a telemetry ping from Fenix on the day in question"
+        "shortDescription": "The profile has sent a baseline or metrics ping from Fenix on the day in question"
+      },
+      {
+        "label": "Any Fenix Baseline Activity",
+        "key": "Any Fenix Baseline Activity",
+        "disabledDimensions": ["os", "attributed"],
+        "shortDescription": "The profile has sent a baseline ping from Fenix on the day in question",
+        "channels": [
+          { "label": "Release (org_mozilla_firefox_beta)", "key": "release" },
+          { "label": "Beta (org_mozilla_firefox_beta)", "key": "beta" },
+          { "label": "Preview (org_mozilla_fenix)", "key": "nightly" },
+          { "label": "Fennec Nightly (org_mozilla_fennec_aurora)", "key": "aurora" },
+          { "label": "Preview Nightly (org_mozilla_fenix_nightly)", "key": "preview nightly" }
+        ]
       },
       {
         "itemType": "divider"

--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -97,7 +97,7 @@
         "disabledDimensions": ["os", "attributed"],
         "shortDescription": "The profile has sent a baseline ping from Fenix on the day in question",
         "channels": [
-          { "label": "Release (org_mozilla_firefox_beta)", "key": "release" },
+          { "label": "Release (org_mozilla_firefox)", "key": "release" },
           { "label": "Beta (org_mozilla_firefox_beta)", "key": "beta" },
           { "label": "Preview (org_mozilla_fenix)", "key": "nightly" },
           { "label": "Fennec Nightly (org_mozilla_fennec_aurora)", "key": "aurora" },

--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -76,7 +76,7 @@
         "label": "Any Mobile Activity",
         "key": "Any Firefox Non-desktop Activity",
         "disabledDimensions": ["os", "attributed"],
-        "shortDescription": "The profile has sent a telemetry ping from any of apps considered for the 2019 Mobile Reach KPI (Fenix, Fennec Android, Fennec iOS, Firefox Lite, FirefoxConnect, Focus Android, and Focus iOS) on the day in question."
+        "shortDescription": "The profile has sent a telemetry ping from any of apps considered for the 2019 Mobile Reach KPI (Firefox Preview, Fennec Android, Fennec iOS, Firefox Lite, FirefoxConnect, Focus Android, and Focus iOS) on the day in question."
       },
       {
         "itemType": "divider"
@@ -86,16 +86,16 @@
         "label": "Fenix"
       },
       {
-        "label": "Any Fenix Activity",
+        "label": "Any Firefox Preview Activity",
         "key": "Any Fenix Activity",
         "disabledDimensions": ["os", "channel", "attributed"],
-        "shortDescription": "The profile has sent a baseline or metrics ping from Fenix on the day in question"
+        "shortDescription": "Legacy definition used in 2019 Mobile Reach KPI: the profile has sent a baseline or metrics ping from Firefox Preview on the day in question"
       },
       {
         "label": "Any Fenix Baseline Activity",
         "key": "Any Fenix Baseline Activity",
         "disabledDimensions": ["os", "attributed"],
-        "shortDescription": "The profile has sent a baseline ping from Fenix on the day in question",
+        "shortDescription": "The profile has sent a baseline ping from Fenix (Firefox for Android) on the day in question",
         "channels": [
           { "label": "Release (org_mozilla_firefox)", "key": "release" },
           { "label": "Beta (org_mozilla_firefox_beta)", "key": "beta" },


### PR DESCRIPTION
I've compiled the new baseline-ping-only Fenix ETL into a temporary analysis table, and integrated it here, so that we can see the new ETL side-by-side with the old in local builds.