### PR TITLE
Fixes specific disabled metric bug

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -84,6 +84,7 @@
   $: if (visible) {
     updateQueryString(storeToQuery($store));
   }
+
 </script>
 
 <!-- PLUGINS ETC. GO RIGHT HERE -->
@@ -133,6 +134,9 @@
               storeKey={selector.key}
               onSelection={option => {
                 if (selector.key === 'usage') {
+                  if (option.disabledMetrics && option.disabledMetrics.includes($store.metric)) {
+                    store.setField('metric', 'all');
+                  }
                   if (option.disabledDimensions) {
                     store.setField('disabledDimensions', [
                       ...option.disabledDimensions


### PR DESCRIPTION
Vicky Chin reported this bug, so it'd be great to get this reviewed & deployed ASAP.

This PR fixes the following workflow bug:

1. select "MAU" for "Any Firefox Desktop Activity"
2. select the usage criterion "New Firefox Desktop Profile Created"

On `master` this should throw an unfortunate error in the console. On this branch it should default to `all` for the metric set available.