### PR TITLE
updates the locale descriptions to be accurate

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -321,17 +321,17 @@
       {
         "label": "English",
         "key": "en",
-        "shortDescription": "en-US, en-GB, en-CA, en-ZA"
+        "shortDescription": "all en locales"
       },
       { "label": "German", "key": "de", "shortDescription": "de" },
       {
         "label": "Spanish",
         "key": "es",
-        "shortDescription": "es-ES, es-MX, es-AR, es-CL"
+        "shortDescription": "all es locales"
       },
       { "label": "French", "key": "fr", "shortDescription": "fr" },
       { "label": "Russian", "key": "ru", "shortDescription": "ru" },
-      { "label": "Chinese", "key": "zh", "shortDescription": "zh-CN, zh-TW" },
+      { "label": "Chinese", "key": "zh", "shortDescription": "all zh locales" },
       {
         "label": "Portuguese",
         "key": "pt",


### PR DESCRIPTION
mgorlick on slack brings up that in the language selector, for `english` we list a bunch of languages but don't include `en-IN` (though it kind of looks like we do from the numbers). Looking at the queries over in `bigquery-etl`, it appears that we are truncating at the language level, leaving off the locale, so this dimension value actually does include `en-IN`. I have no problem with that, but if we don't change the ETL we should probably update the descriptions.

Assigning @jklukas to double-check my logic here ~