### PR TITLE
Make channel list for "Any Mobile Activity" match Fennec

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -76,7 +76,14 @@
         "label": "Any Mobile Activity",
         "key": "Any Firefox Non-desktop Activity",
         "disabledDimensions": ["os", "attributed"],
-        "shortDescription": "The profile has sent a telemetry ping from any of apps considered for the 2019 Mobile Reach KPI (Fenix, Fennec Android, Fennec iOS, Firefox Lite (excluding CN), FirefoxConnect, Focus Android, Focus iOS, and Lockwise) on the day in question."
+        "shortDescription": "The profile has sent a telemetry ping from any of apps considered for the 2019 Mobile Reach KPI (Fenix, Fennec Android, Fennec iOS, Firefox Lite (excluding CN), FirefoxConnect, Focus Android, Focus iOS, and Lockwise) on the day in question.",
+        "channels": [
+          { "label": "Release", "key": "release" },
+          { "label": "Beta", "key": "beta" },
+          { "label": "Aurora", "key": "aurora" },
+          { "label": "Nightly", "key": "nightly" },
+          { "label": "Other", "key": "Other" }
+        ]
       },
       {
         "itemType": "divider"


### PR DESCRIPTION
Currently, we are showing the desktop channels for "Any Mobile Activity",
but we should instead be showing the same channels as Fennec Android,
which is the mobile product with the most diverse set of channels.