### PR TITLE
Baseline-only Fenix usage; break out Firefox Preview

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -93,10 +93,36 @@
         "label": "Fenix"
       },
       {
+        "label": "Any Fenix or Firefox Preview Activity",
+        "key": "Any Preview+Fenix Activity",
+        "disabledDimensions": ["os", "attributed"],
+        "shortDescription": "The profile has sent a Glean 'baseline' ping from Fenix or Firefox Preview on the day in question",
+        "channels": [
+          { "label": "Release", "key": "release" },
+          { "label": "Beta", "key": "beta" },
+          { "label": "Nightly", "key": "nightly" }
+        ]
+      },
+      {
         "label": "Any Fenix Activity",
         "key": "Any Fenix Activity",
-        "disabledDimensions": ["os", "channel", "attributed"],
-        "shortDescription": "The profile has sent a Glean 'baseline' or 'metrics' ping from Fenix on the day in question"
+        "disabledDimensions": ["os", "attributed"],
+        "shortDescription": "The profile has sent a Glean 'baseline' ping from Fenix on the day in question; excludes Firefox Preview",
+        "channels": [
+          { "label": "Release (org-mozilla-firefox)", "key": "release" },
+          { "label": "Beta (org-mozilla-firefox-beta)", "key": "beta" },
+          { "label": "Nightly (org-mozilla-fennec-aurora)", "key": "nightly" }
+        ]
+      },
+      {
+        "label": "Any Firefox Preview Activity",
+        "key": "Any Firefox Preview Activity",
+        "disabledDimensions": ["os", "attributed"],
+        "shortDescription": "The profile has sent a Glean 'baseline' ping from Firefox Preview on the day in question",
+        "channels": [
+          { "label": "Beta (org-mozilla-fenix)", "key": "beta" },
+          { "label": "Nightly (org-mozilla-fenix-nightly)", "key": "nightly" }
+        ]
       },
       {
         "itemType": "divider"

--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -98,9 +98,12 @@
         "disabledDimensions": ["os", "attributed"],
         "shortDescription": "The profile has sent a Glean 'baseline' ping from Fenix or Firefox Preview on the day in question",
         "channels": [
-          { "label": "Release", "key": "release" },
-          { "label": "Beta", "key": "beta" },
-          { "label": "Nightly", "key": "nightly" }
+          { "label": "Release", "key": "release",
+            "shortDescription": "org-mozilla-firefox" },
+          { "label": "Beta", "key": "beta",
+            "shortDescription": "org-mozilla-firefox-beta and org-mozilla-fenix" },
+          { "label": "Nightly", "key": "nightly",
+            "shortDescription": "org-mozilla-fennec-aurora and org-mozilla-fenix-nightly" }
         ]
       },
       {
@@ -109,9 +112,12 @@
         "disabledDimensions": ["os", "attributed"],
         "shortDescription": "The profile has sent a Glean 'baseline' ping from Fenix on the day in question; excludes Firefox Preview",
         "channels": [
-          { "label": "Release (org-mozilla-firefox)", "key": "release" },
-          { "label": "Beta (org-mozilla-firefox-beta)", "key": "beta" },
-          { "label": "Nightly (org-mozilla-fennec-aurora)", "key": "nightly" }
+          { "label": "Release", "key": "release",
+            "shortDescription": "org-mozilla-firefox" },
+          { "label": "Beta", "key": "beta",
+            "shortDescription": "org-mozilla-firefox-beta" },
+          { "label": "Nightly", "key": "nightly",
+            "shortDescription": "org-mozilla-fennec-aurora" }
         ]
       },
       {
@@ -120,8 +126,10 @@
         "disabledDimensions": ["os", "attributed"],
         "shortDescription": "The profile has sent a Glean 'baseline' ping from Firefox Preview on the day in question",
         "channels": [
-          { "label": "Beta (org-mozilla-fenix)", "key": "beta" },
-          { "label": "Nightly (org-mozilla-fenix-nightly)", "key": "nightly" }
+          { "label": "Beta", "key": "beta",
+            "shortDescription": "org-mozilla-fenix" },
+          { "label": "Nightly", "key": "nightly",
+            "shortDescription": "org-mozilla-fenix-nightly" }
         ]
       },
       {


### PR DESCRIPTION
The naming here matches [the mapping in the Fenix KPI reporting changes proposal](https://docs.google.com/document/d/1Ym4eZyS0WngEP6WdwJjmCoxtoQbJSvORxlQwZpuSV2I/edit#heading=h.69hvvg35j8un)

Depends on https://github.com/mozilla/bigquery-etl/pull/887 and https://github.com/mozilla/telemetry-airflow/pull/940