### PR TITLE
Display proper Play Store app IDs

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -99,11 +99,11 @@
         "shortDescription": "The profile has sent a Glean 'baseline' ping from Fenix or Firefox Preview on the day in question",
         "channels": [
           { "label": "Release", "key": "release",
-            "shortDescription": "org-mozilla-firefox" },
+            "shortDescription": "org.mozilla.firefox" },
           { "label": "Beta", "key": "beta",
-            "shortDescription": "org-mozilla-firefox-beta and org-mozilla-fenix" },
+            "shortDescription": "org.mozilla.firefox_beta and org.mozilla.fenix" },
           { "label": "Nightly", "key": "nightly",
-            "shortDescription": "org-mozilla-fennec-aurora and org-mozilla-fenix-nightly" }
+            "shortDescription": "org.mozilla.fennec_aurora and org.mozilla.fenix.nightly" }
         ]
       },
       {
@@ -113,11 +113,11 @@
         "shortDescription": "The profile has sent a Glean 'baseline' ping from Fenix on the day in question; excludes Firefox Preview",
         "channels": [
           { "label": "Release", "key": "release",
-            "shortDescription": "org-mozilla-firefox" },
+            "shortDescription": "org.mozilla.firefox" },
           { "label": "Beta", "key": "beta",
-            "shortDescription": "org-mozilla-firefox-beta" },
+            "shortDescription": "org.mozilla.firefox_beta" },
           { "label": "Nightly", "key": "nightly",
-            "shortDescription": "org-mozilla-fennec-aurora" }
+            "shortDescription": "org.mozilla.fennec_aurora" }
         ]
       },
       {
@@ -127,9 +127,9 @@
         "shortDescription": "The profile has sent a Glean 'baseline' ping from Firefox Preview on the day in question",
         "channels": [
           { "label": "Beta", "key": "beta",
-            "shortDescription": "org-mozilla-fenix" },
+            "shortDescription": "org.mozilla.fenix" },
           { "label": "Nightly", "key": "nightly",
-            "shortDescription": "org-mozilla-fenix-nightly" }
+            "shortDescription": "org.mozilla.fenix.nightly" }
         ]
       },
       {


### PR DESCRIPTION
For products using Glean, app IDs end up getting transformed into three
separate formats:

- Source app ID from the play store: org.mozilla.firefox_beta
- Document namespace sent in pings: org-mozilla-firefox-beta
- Dataset name in BigQuery: org_mozilla_firefox_beta

In GUD, we are currently showing the document namespace, but it seems more
correct and likely more recognizable to Android developers if we use the
source app ID as it exists in the Play Store.