### PR TITLE
[current staging] change from 'light' / 'dark' terminology to 'Attributed' / 'Unattributed'

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -282,8 +282,8 @@
     "whereStyle": "boolean",
     "inMenu": true,
     "values": [
-      { "label": "Attributed Installs", "key": "TRUE" },
-      { "label": "Unattributed Installs", "key": "FALSE" }
+      { "label": "Attributed", "key": "TRUE" },
+      { "label": "Unattributed", "key": "FALSE" }
     ]
   },
   "metricOptions": {


### PR DESCRIPTION
We need this PR since for now, what people know as the GUD frontend is now frozen in the `prototype` branch. This will apply the change for this particular branch. See #82 for the same PR targeting the dev / prod workflow.