### PR TITLE
[dev] change from 'light' / 'dark' terminology to 'Attributed' / 'Unattributed'

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -282,8 +282,8 @@
     "whereStyle": "boolean",
     "inMenu": true,
     "values": [
-      { "label": "Attributed Installs", "key": "TRUE" },
-      { "label": "Unattributed Installs", "key": "FALSE" }
+      { "label": "Attributed", "key": "TRUE" },
+      { "label": "Unattributed", "key": "FALSE" }
     ]
   },
   "metricOptions": {


### PR DESCRIPTION
This fixes the terminology in our new dev instance, which means it will apply to the future version of GUD that is in development.