### PR TITLE
Remove appId labels from Fenix channels

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -120,18 +120,15 @@
         "channels": [
           {
             "label": "Release",
-            "key": "release",
-            "shortDescription": "org.mozilla.firefox"
+            "key": "release"
           },
           {
             "label": "Beta",
-            "key": "beta",
-            "shortDescription": "org.mozilla.firefox_beta and org.mozilla.fenix"
+            "key": "beta"
           },
           {
             "label": "Nightly",
-            "key": "nightly",
-            "shortDescription": "org.mozilla.fennec_aurora and org.mozilla.fenix.nightly"
+            "key": "nightly"
           }
         ]
       },
@@ -143,18 +140,15 @@
         "channels": [
           {
             "label": "Release",
-            "key": "release",
-            "shortDescription": "org.mozilla.firefox"
+            "key": "release"
           },
           {
             "label": "Beta",
-            "key": "beta",
-            "shortDescription": "org.mozilla.firefox_beta"
+            "key": "beta"
           },
           {
             "label": "Nightly",
-            "key": "nightly",
-            "shortDescription": "org.mozilla.fennec_aurora"
+            "key": "nightly"
           }
         ]
       },
@@ -166,13 +160,11 @@
         "channels": [
           {
             "label": "Beta",
-            "key": "beta",
-            "shortDescription": "org.mozilla.fenix"
+            "key": "beta"
           },
           {
             "label": "Nightly",
-            "key": "nightly",
-            "shortDescription": "org.mozilla.fenix.nightly"
+            "key": "nightly"
           }
         ]
       },


### PR DESCRIPTION
Should wait until https://github.com/mozilla/bigquery-etl/pull/1245 is merged.

The mapping from Fenix channels to appIds is no longer straight-forward, so we remove those shortDescription values.