### PR TITLE
Remove appId labels from Fenix channels (prototype)

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -100,18 +100,15 @@
         "channels": [
           {
             "label": "Release",
-            "key": "release",
-            "shortDescription": "org.mozilla.firefox"
+            "key": "release"
           },
           {
             "label": "Beta",
-            "key": "beta",
-            "shortDescription": "org.mozilla.firefox_beta and org.mozilla.fenix"
+            "key": "beta"
           },
           {
             "label": "Nightly",
-            "key": "nightly",
-            "shortDescription": "org.mozilla.fennec_aurora and org.mozilla.fenix.nightly"
+            "key": "nightly"
           }
         ]
       },
@@ -123,18 +120,15 @@
         "channels": [
           {
             "label": "Release",
-            "key": "release",
-            "shortDescription": "org.mozilla.firefox"
+            "key": "release"
           },
           {
             "label": "Beta",
-            "key": "beta",
-            "shortDescription": "org.mozilla.firefox_beta"
+            "key": "beta"
           },
           {
             "label": "Nightly",
-            "key": "nightly",
-            "shortDescription": "org.mozilla.fennec_aurora"
+            "key": "nightly"
           }
         ]
       },
@@ -146,13 +140,11 @@
         "channels": [
           {
             "label": "Beta",
-            "key": "beta",
-            "shortDescription": "org.mozilla.fenix"
+            "key": "beta"
           },
           {
             "label": "Nightly",
-            "key": "nightly",
-            "shortDescription": "org.mozilla.fenix.nightly"
+            "key": "nightly"
           }
         ]
       },


### PR DESCRIPTION
prototype version of #107 