### PR TITLE
Add Japan to the country list

### DIFF
--- a/src/stores/options.json
+++ b/src/stores/options.json
@@ -451,6 +451,7 @@
       { "label": "Canada", "key": "CA" },
       { "label": "Spain", "key": "ES" },
       { "label": "Indonesia", "key": "ID" },
+      { "label": "Japan", "key": "JP" },
       { "label": "Kenya", "key": "KE" }
     ]
   },


### PR DESCRIPTION
Resolves #112

Relies on https://github.com/mozilla/bigquery-etl/pull/1352 to make JP available in the underlying tables.