### PR TITLE
fixes page redirection issue due to view not being in hash route

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -26,7 +26,7 @@
 
   function useComponent(thisView = undefined) {
     return (ctx, next) => {
-      const params = ctx.params;
+      const {params} = ctx;
       const urlView = params.view;
       currentView = thisView || urlView;
       store.setField('mode', currentView);
@@ -37,11 +37,11 @@
   }
 
   function updateAfterMoving(ctx, next) {
-    ctx.path += '?' + storeToQuery($store);
+    ctx.path += `?${  storeToQuery($store)}`;
     ctx.save();
   }
 
-  page('/', useComponent('explore'), updateAfterMoving);
+  page.redirect('/', '/explore')
   page('/:view', useComponent(), updateAfterMoving);
   page({ hashbang: true });
 


### PR DESCRIPTION
fixes #119 

A fresh page-load with no query string wasn't catching the view in the hash, ie `#!explore?param=...`. It was just making `?param=...`, which confused the instantiation. This was easily fixed by "redirecting" `/` to `/explore` by default, which was kind of happening already. This bug that existed before kept it so that there were cases where a user couldn't copy and paste the URL and expect to get the same thing, since the store instantiation was confused by the structure.